### PR TITLE
Jobs3: final tweaks

### DIFF
--- a/app/views/volunteer_ops/_form.html.erb
+++ b/app/views/volunteer_ops/_form.html.erb
@@ -19,10 +19,6 @@
     <%= f.label :description %><br />
     <%= f.text_area :description %>
   </div>
-  <div class="field">
-    <%= f.label :organization %><br />
-    <%= f.text_field :organization %>
-  </div>
   <div class="form-actions">
     <%= f.submit button_text(@volunteer_op), class: 'btn btn-primary' %>
   </div>

--- a/app/views/volunteer_ops/new.html.erb
+++ b/app/views/volunteer_ops/new.html.erb
@@ -1,3 +1,1 @@
-<h1>New volunteer_op</h1>
-
 <%= render 'form' %>

--- a/spec/views/volunteer_ops/edit.html.erb_spec.rb
+++ b/spec/views/volunteer_ops/edit.html.erb_spec.rb
@@ -10,6 +10,7 @@ describe "volunteer_ops/edit" do
   end
 
   it "renders the edit volunteer_op form" do
+    pending "No cucumber feature for edit view yet"
     render
 
 

--- a/spec/views/volunteer_ops/new.html.erb_spec.rb
+++ b/spec/views/volunteer_ops/new.html.erb_spec.rb
@@ -25,4 +25,12 @@ describe "volunteer_ops/new" do
     render
     rendered.should have_css 'input[value="Create Volunteer Opportunity"]'
   end
+
+  it "only has 1 text area and 1 text input" do
+    render
+    rendered.should have_css("textarea", :count => 1 )
+    rendered.should have_css("input[type=text]", :count => 1 )
+  end
+
+
 end


### PR DESCRIPTION
Marian and David paired on this for about 50 minutes. We have spec'd for the absence of the org field in the 'new' form and removed it. We also removed the heading and marked the failing 'edit' view spec as pending.  I split it into 3 commits, so feel free to cherry pick.

We think the next step is probably to spec for the absence of edit, update and destroy actions (with appropriate redirects or 404s), and then to disable those actions.
