### PR TITLE
Refactoring org reports controller jon

### DIFF
--- a/app/services/controller_extension.rb
+++ b/app/services/controller_extension.rb
@@ -5,7 +5,6 @@ module ControllerExtension
               .prepend(name_of controller)
               .camelize
               .constantize
-              .check_permissions(controller)
   end
 
   def self.name_of(controller)

--- a/app/services/controller_extensions/organisations/defaults.rb
+++ b/app/services/controller_extensions/organisations/defaults.rb
@@ -1,6 +1,8 @@
 module ControllerExtensions
   module Organisations::Defaults
 
+    # organisations_path(service: 'without_users')
+
     def set_params
       defaults = {
         layout: 'two_columns',
@@ -15,17 +17,13 @@ module ControllerExtensions
 
     def set_instance_variables
       @organisations = apply_scopes(Organisation)
+      @json = gmap4rails_with_popup_partial(@organisations, 'popup')
+      @category_options = Category.html_drop_down_options
     end
 
     def apply_scopes(klass)
       params[:scopes].each { |s| klass = klass.send(s) }
       klass
-    end
-
-    module ClassMethods
-      def check_permissions(controller)
-        Organisations::Index
-      end
     end
   end
 end

--- a/app/services/controller_extensions/organisations/defaults.rb
+++ b/app/services/controller_extensions/organisations/defaults.rb
@@ -1,6 +1,5 @@
 module ControllerExtensions
   module Organisations::Defaults
-    extend ActiveSupport::Concern
 
     def set_params
       defaults = {

--- a/app/services/controller_extensions/organisations/index.rb
+++ b/app/services/controller_extensions/organisations/index.rb
@@ -8,8 +8,6 @@ module ControllerExtensions
 
     def set_instance_variables
       super
-      @json = gmap4rails_with_popup_partial(@organisations, 'popup')
-      @category_options = Category.html_drop_down_options
     end
   end
 end

--- a/app/services/controller_extensions/organisations/without_users.rb
+++ b/app/services/controller_extensions/organisations/without_users.rb
@@ -15,9 +15,5 @@ module ControllerExtensions
       super
       @resend_invitation = false
     end
-
-    def self.check_permissions(controller)
-      controller.send(:admin?) ? self : super
-    end
   end
 end

--- a/spec/controllers/organisations_controller_spec.rb
+++ b/spec/controllers/organisations_controller_spec.rb
@@ -188,7 +188,9 @@ describe OrganisationsController do
       end
 
       context 'admins' do
+        let!(:org){create(:organisation, email: 'well@hello.there')}
         before do
+
           controller.stub admin?: true
           get :index, service: 'without_users'
         end
@@ -214,7 +216,6 @@ describe OrganisationsController do
           end
 
           it do
-            org = create(:organisation, email: 'well@hello.there')
             expect(assigns(:organisations)).to include org
           end
         end

--- a/spec/controllers/organisations_controller_spec.rb
+++ b/spec/controllers/organisations_controller_spec.rb
@@ -134,28 +134,28 @@ describe OrganisationsController do
         controller.stub example.metadata.slice(:admin?)
       end
 
-      context admin?: false do
+      context 'normal user, no override, scope', admin?: false do
         it do
           get :index, params
           expect(controller.params[:scopes]).to eq ['order_by_most_recent']
         end
       end
 
-      context admin?: true do
+      context 'admin user, no override, scope', admin?: true do
         it do
           get :index, params
           expect(controller.params[:scopes]).to eq ['order_by_most_recent']
         end
       end
 
-      context admin?: false, scopes: ['hello'] do
+      context 'normal user, override, scope', admin?: false, scopes: ['hello'] do
         it do
           get :index, params
           expect(controller.params[:scopes]).to eq ['order_by_most_recent']
         end
       end
 
-      context admin?: true, scopes: ['hello'] do
+      context 'admin user, override, scope', admin?: true, scopes: ['hello'] do
         it do
           expect(Organisation).to receive(:hello).and_return Organisation.all
           get :index, params

--- a/spec/services/controller_extension_spec.rb
+++ b/spec/services/controller_extension_spec.rb
@@ -1,0 +1,117 @@
+require 'spec_helper'
+require 'debugger'
+
+class DummyController
+
+  attr_accessor :params
+  attr_reader :organisations
+  attr_reader :resend_invitation
+  attr_reader :json
+  attr_reader :category_options
+
+  def initialize
+    @params = {}
+  end
+
+  def controller_name
+    'organisations'
+  end
+end
+
+describe ControllerExtensions::Organisations::Defaults do
+  let(:controller) { DummyController.new }
+  let(:orgs) { [(double :organisation), (double :organisation)] }
+
+  context ControllerExtensions::Organisations::Index do
+    before do
+      expect(controller).to receive(:gmap4rails_with_popup_partial).with(orgs, 'popup')
+      expect(Category).to receive(:html_drop_down_options)
+      controller.stub(example.metadata.slice(:admin?))
+      controller.params = example.metadata.slice(:scopes)
+      controller.params[:service] ||= 'index'
+      controller.extend ControllerExtension.for controller
+    end
+
+    context 'only an admin can override scopes and everyone receives a sensible default' do
+      it 'normal user with no override gets default scope \'order_by_most_recent\'', admin?: false do
+        expect(Organisation).to receive(:order_by_most_recent).and_return orgs
+        controller.set_params
+        controller.set_instance_variables
+        expect(controller.params[:scopes]).to eq ['order_by_most_recent']
+      end
+
+      it 'admin user with no override gets default scope \'order_by_most_recent\'', admin?: true do
+        expect(Organisation).to receive(:order_by_most_recent).and_return orgs
+        controller.set_params
+        controller.set_instance_variables
+        expect(controller.params[:scopes]).to eq ['order_by_most_recent']
+      end
+
+      it 'normal user with override gets default scope \'order_by_most_recent\'', admin?: false, scopes: ['hello'] do
+        expect(Organisation).to receive(:order_by_most_recent).and_return orgs
+        controller.set_params
+        controller.set_instance_variables
+        expect(controller.params[:scopes]).to eq ['order_by_most_recent']
+      end
+
+      it 'admin user with override gets new scope \'hello\'', admin?: true, scopes: ['hello'] do
+        expect(Organisation).to receive(:hello).and_return orgs
+        controller.set_params
+        controller.set_instance_variables
+        expect(controller.params[:scopes]).to eq ['hello']
+      end
+    end
+  end
+
+  context ControllerExtensions::Organisations::WithoutUsers do
+    it 'non-admins will not benefit from extensions params overriding abilities' do
+      controller.stub admin?: false
+      controller.params[:service] = 'without_users'
+      controller.extend ControllerExtension.for controller
+      controller.set_params
+      expect(controller.params[:template]).to eq 'organisations/index'
+    end
+
+    context 'admins' do
+      before do
+        controller.stub admin?: true
+        controller.params[:service] = 'without_users'
+        controller.extend ControllerExtension.for controller
+        controller.set_params
+      end
+
+      context 'will have new params set' do
+        {
+            template: 'without_users_index',
+            layout: 'invitation_table',
+            scopes: ['not_null_email','null_users','without_matching_user_emails'],
+        }.each do |k, v|
+          it do
+            if k == :template
+              v = v.prepend(controller.controller_name + '/')
+            end
+            expect(controller.params[k]).to eq v
+          end
+        end
+      end
+
+      context 'instance variables set' do
+        before do
+          expect(controller).to receive(:gmap4rails_with_popup_partial).with(orgs, 'popup')
+          expect(Category).to receive(:html_drop_down_options)
+          expect(Organisation).to receive(:without_matching_user_emails).and_return orgs
+        end
+        it do
+          controller.set_instance_variables
+          expect(controller.resend_invitation).to eq false
+        end
+
+        it do
+          controller.set_instance_variables
+          expect(controller.organisations).to eq orgs
+        end
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
I've done some simplification of the controller extension (removing permissions to avoid doubling up on the admin check) and also created a unit test that tests the extension completely independently of rails (although contains more mocking and stubbing).  In principle the controller spec could now be deleted?  Although I think it is interesting to reflect what the three different specs (acceptance, controller and unit) buy us and which combinations we should prefer.

My main concerns are that the controller specs get very long and are difficult to maintain.  Maintenance difficulty is also an issue with the unit test, but at least it is more specifically targeted, so that when and if one wants to work on changing the controller extension then it's clear where the tests are for that.  Perhaps the unit test would be improved by using the new rspec features that allow doubles to be tracked, e.g. we could be creating a mock controller that is at least loosely linked to the existing controllers, although that maybe defeats the separation mantra ...
